### PR TITLE
Update URLs in meta-data files. Also add fundamental tags to SUPPORTE…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,12 +53,12 @@ naming them in the command line; if none is specified all will be executed.
 
 
 
-.. _PyAIML: https://github.com/cdwfs/pyaiml
+.. _PyAIML: https://github.com/Calysto/aiml  (forked from https://github.com/cdwfs/pyaiml)
 .. _Free ALICE AIML set: https://code.google.com/archive/p/aiml-en-us-foundation-alice/
 .. _LGPL: http://www.gnu.org/licenses/lgpl.html
-.. _ALICE AI Foundation: http://alice.pandorabots.com/
+.. _AIML Foundation: http://www.aiml.foundation/index.html
 .. _bot.py: aiml/script/bot.py
-.. _AIML 1.0.1: http://www.alicebot.org/TR/2011/
+.. _AIML 1.0.1: https://github.com/AIML-Foundation/AIML-1.0.1
 
 ------------------------------------------------------------------------------
 

--- a/SUPPORTED_TAGS.txt
+++ b/SUPPORTED_TAGS.txt
@@ -1,10 +1,11 @@
 This document describes the current state of PyAIML's compliance
 to the AIML 1.0.1 standard.  The full AIML reference manual can be
-found online at http://alicebot.org/TR/2001/WD-aiml.
+found online at https://github.com/AIML-Foundation/AIML-1.0.1 .
 
 The following tags are currently supported:
 
 	<bot name="name"> (see notes)
+	<category>
 	<condition>
 	<date>
 	<formal>
@@ -15,6 +16,7 @@ The following tags are currently supported:
 	<learn>
 	<li>
 	<lowercase>
+	<pattern>
 	<person>
 	<person2>
 	<random>
@@ -25,6 +27,7 @@ The following tags are currently supported:
 	<srai>
 	<star>
 	<system>
+	<template>
 	<that>
 	<thatstar>
 	<think>


### PR DESCRIPTION
Perhaps category, pattern, and template are considered too fundamental to mention, but I think completeness and clarity are best served by including in supported tags doc. 
Also, some of the URLs were obsolete, some even parked domains. Here is my shot at appropriate replacments.